### PR TITLE
Reset color when an error occured

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,42 +62,46 @@ MAGENTA			:= \033[0;95m
 CYAN			:= \033[0;96m
 WHITE			:= \033[0;97m
 
+define on_err_reset_color
+	echo -n "$(DEF_COLOR)" && exit 1
+endef
+
 all: $(NAME)
 
 $(LEXER_TEST): $(LIBFT) $(LEXER_OBJ)
 	@echo "$(RED)Making test binary: $(LEXER_TEST)"
 	@printf "$(MAGENTA)"
-	$(CC) $(LEXER_TEST_SRC) $(LIBFT) $(CFLAGS) $(LDFLAGS) -o $(LEXER_TEST)
+	$(CC) $(LEXER_TEST_SRC) $(LIBFT) $(CFLAGS) $(LDFLAGS) -o $(LEXER_TEST) || $(call on_err_reset_color)
 	@printf "$(LEXER_TEST) done !$(DEF_COLOR)\n"
 
 $(EXEC_TEST): $(LIBFT) $(EXEC_OBJ)
 	@echo "$(RED)Making test binary: $(EXEC_TEST)"
 	@printf "$(MAGENTA)"
-	$(CC) $(EXEC_TEST_SRC) $(LIBFT) $(CFLAGS) $(LDFLAGS) -o $(EXEC_TEST)
+	$(CC) $(EXEC_TEST_SRC) $(LIBFT) $(CFLAGS) $(LDFLAGS) -o $(EXEC_TEST) || $(call on_err_reset_color)
 	@printf "$(EXEC_TEST) done !$(DEF_COLOR)\n"
 
 $(AST_TEST): $(LIBFT) $(AST_TEST_OBJ)
 	@echo "$(RED)Making test binary: $(AST_TEST)"
 	@printf "$(MAGENTA)"
-	$(CC) $(AST_TEST_SRC) $(LIBFT) $(CFLAGS) $(LDFLAGS) -o $(AST_TEST)
+	$(CC) $(AST_TEST_SRC) $(LIBFT) $(CFLAGS) $(LDFLAGS) -o $(AST_TEST) || $(call on_err_reset_color)
 	@printf "$(AST_TEST) done !$(DEF_COLOR)\n"
 
 $(REGEX_TEST): $(LIBFT) $(REGEX_OBJ)
 	@echo "$(RED)Making test binary: $(REGEX_TEST)"
 	@printf "$(MAGENTA)"
-	$(CC) $(REGEX_TEST_SRC) $(LIBFT) $(CFLAGS) $(LDFLAGS) -o $(REGEX_TEST)
+	$(CC) $(REGEX_TEST_SRC) $(LIBFT) $(CFLAGS) $(LDFLAGS) -o $(REGEX_TEST) || $(call on_err_reset_color)
 	@printf "$(REGEX_TEST) done !$(DEF_COLOR)\n"
 
 $(NAME): $(LIBFT) $(OBJDIR) $(OBJ)
 	@echo "$(GREEN)Making binary: $(NAME)"
 	@printf "$(MAGENTA)"
-	@$(CC) $(OBJ) $(LIBFT) $(CFLAGS) $(LDFLAGS) -o $(NAME)
+	@$(CC) $(OBJ) $(LIBFT) $(CFLAGS) $(LDFLAGS) -o $(NAME) || $(call on_err_reset_color)
 	@printf "Done !$(DEF_COLOR)\n"
 
 $(OBJDIR)/%.o: source/%.c
 	@printf '$(YELLOW)Compiling : %-45s $(CYAN)-->	$(YELLOW)%-30s\n' "$<" "$@";
 	@printf "$(BLUE)"
-	@$(CC) $(CFLAGS) -c $< -o $@
+	@$(CC) $(CFLAGS) -c $< -o $@ || $(call on_err_reset_color)
 	@printf "$(DEF_COLOR)"
 
 clean:


### PR DESCRIPTION
When an error occurs, the color functionality isn't reset properly. To address this, I've added a function to handle the reset in such cases.

Without fix:
![image](https://github.com/user-attachments/assets/da91eb56-1141-4803-9622-d14b664a1c6b)

With fix:
![image](https://github.com/user-attachments/assets/46025915-e79c-469f-8974-42eba46602ca)

